### PR TITLE
Circumvent partnerUserId restriction

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,11 +1,16 @@
 import requests
 import json
+import random
 
 QUANTITY = 2
 base_path = "https://discord.com/billing/partner-promotions/1180231712274387115/"
 url = 'https://api.discord.gx.games/v1/direct-fulfillment'
+
+# Generates 64 character hex code to circumvent partnerUserId restriction
+hex_code = ''.join(random.choice('0123456789abcdef') for n in range(64))
+
 payload = {
-    "partnerUserId": "d05d65629f9b076a55c0661fcf7e9871bbf7052042d26b5185784d29f06081ab"
+    "partnerUserId": f"{hex_code}"
 }
 
 headers = {

--- a/main.py
+++ b/main.py
@@ -6,13 +6,6 @@ QUANTITY = 2
 base_path = "https://discord.com/billing/partner-promotions/1180231712274387115/"
 url = 'https://api.discord.gx.games/v1/direct-fulfillment'
 
-# Generates 64 character hex code to circumvent partnerUserId restriction
-hex_code = ''.join(random.choice('0123456789abcdef') for n in range(64))
-
-payload = {
-    "partnerUserId": f"{hex_code}"
-}
-
 headers = {
     'authority': 'api.discord.gx.games',
     'accept': '*/*',
@@ -30,6 +23,13 @@ headers = {
 }
 
 def gen():
+    # Generates 64 character hex code to circumvent partnerUserId restriction
+    hex_code = ''.join(random.choice('0123456789abcdef') for n in range(64))
+
+    payload = {
+        "partnerUserId": f"{hex_code}"
+    }
+    
     response = requests.post(url, json=payload, headers=headers)
 
     # Handling rate limiting


### PR DESCRIPTION
Circumvents restriction whereby a unique 'partnerUserId' is required as payload per link generation.

Fails with a x/16^64 chance, where x is the total number of links generated by users.